### PR TITLE
mali_bifrost: fix undefined reference to `get_gl_mem_by_pid`

### DIFF
--- a/drivers/gpu/arm/midgard/platform/mtk_platform_common/mtk_platform_common.c
+++ b/drivers/gpu/arm/midgard/platform/mtk_platform_common/mtk_platform_common.c
@@ -166,6 +166,23 @@ static int proc_gpu_memoryusage_show(struct seq_file *m, void *v)
 	return ret;
 }
 
+#ifdef VENDOR_EDIT
+#define P2K(x) ((x) << (PAGE_SHIFT - 10)) /* Converts #Pages to KB */
+int get_gl_mem_by_pid(pid_t pid)
+{
+   ssize_t ret = 0;
+#ifdef ENABLE_MTK_MEMINFO
+   int i = 0;
+   for (i = 0; (i < MTK_MEMINFO_SIZE) && (g_mtk_gpu_meminfo[i].pid != 0); i++) {
+	if(g_mtk_gpu_meminfo[i].pid == pid) {  //no lock protecte?
+	return P2K(g_mtk_gpu_meminfo[i].used_pages);
+	}}
+#endif /* ENABLE_MTK_MEMINFO */
+	return ret;
+}
+EXPORT_SYMBOL(get_gl_mem_by_pid);
+#endif
+
 static int kbasep_gpu_memoryusage_debugfs_open(struct inode *in, struct file *file)
 {
 	return single_open(file, proc_gpu_memoryusage_show, NULL);


### PR DESCRIPTION
this happened because of the gpu mali_bifrost oss driver, which does not include vendor edits in it.
it throws modpost error like:

/../kernel/aarch64-gcc/bin/aarch64-linux-gnu-ld: fs/proc/base.o: in function `proc_pid_real_phymemory_read':
/../kernel/out/../fs/proc/base.c:427: undefined reference to `get_gl_mem_by_pid'

add relevant vendor edits and error fixed.